### PR TITLE
Add missing line to default cli config

### DIFF
--- a/docs/cli/config/named-profiles.md
+++ b/docs/cli/config/named-profiles.md
@@ -16,6 +16,9 @@ You can configure additional profiles by adding entries to the `~/.config/thabal
 The following example shows a credentials file with two profiles:
 
 ```ini
+[core]
+default_timezone = utc
+
 ; User/Password based authenticator
 [default]
 account_url = https://thexample001.thabala.com

--- a/docs/cli/config/overview.md
+++ b/docs/cli/config/overview.md
@@ -8,7 +8,10 @@ used at the end of the installation to [validate the installation](/cli/install/
 
 The automatically generated default config at `~/.config/thabala/cli.cfg`:
 
-```
+```ini
+[core]
+default_timezone = utc
+
 [default]
 account_url = 
 authenticator = 
@@ -32,6 +35,9 @@ accounts or to the same account but as multiple users or multiple authentication
 
 Example `~/.config/thabala/cli.cfg` with two profiles:
 ```ini
+[core]
+default_timezone = utc
+
 ; User/Password based authenticator
 [default]
 account_url = https://thexample001.thabala.com


### PR DESCRIPTION
## Description

Example Thabala CLI `cli.cfg` file is not in sync with the actual automatically generated `cli.cfg`.

## Solution description

Update documentation to use the actually generated `cli.cfg`. file in the examples.

## Checklist

- [ ] Made great code
