### PR TITLE
Bump docusaurus from 2.1.0 to 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 ### Installation
 
 ```
-$ npm install
+$ npm ci
 ```
 
 ### Local Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@cmfcmf/docusaurus-search-local": "^0.11.0",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/preset-classic": "2.1.0",
+        "@docusaurus/core": "^2.2.0",
+        "@docusaurus/preset-classic": "^2.2.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "docusaurus-plugin-image-zoom": "^0.1.1",
@@ -19,7 +19,7 @@
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "2.1.0"
+        "@docusaurus/module-type-aliases": "^2.2.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -1999,18 +1999,18 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.0.tgz",
+      "integrity": "sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.0.tgz",
+      "integrity": "sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
+        "@algolia/autocomplete-core": "1.7.2",
+        "@algolia/autocomplete-preset-algolia": "1.7.2",
+        "@docsearch/css": "3.3.0",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
@@ -2030,10 +2030,35 @@
         }
       }
     },
+    "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.2.tgz",
+      "integrity": "sha512-eclwUDC6qfApNnEfu1uWcL/rudQsn59tjEoUYZYE2JSXZrHLRjBUGMxiCoknobU2Pva8ejb0eRxpIYDtVVqdsw==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.7.2"
+      }
+    },
+    "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.2.tgz",
+      "integrity": "sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.7.2"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-shared": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.2.tgz",
+      "integrity": "sha512-QCckjiC7xXHIUaIL3ektBtjJ0w7tTA3iqKcAE/Hjn1lZ5omp7i3Y4e09rAr9ZybqirL7AbxCLLq0Ra5DDPKeug=="
+    },
     "node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -2045,13 +2070,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/cssnano-preset": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -2119,9 +2144,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.2.0.tgz",
+      "integrity": "sha512-mAAwCo4n66TMWBH1kXnHVZsakW9VAXJzTO4yZukuL3ro4F+JtkMwKfh42EG75K/J/YIFQG5I/Bzy0UH/hFxaTg==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -2133,9 +2158,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
-      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
+      "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2145,14 +2170,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
-      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
+      "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2176,12 +2201,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
+      "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
+        "@docusaurus/types": "2.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2195,17 +2220,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
-      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.2.0.tgz",
+      "integrity": "sha512-0mWBinEh0a5J2+8ZJXJXbrCk1tSTNf7Nm4tYAl5h2/xx+PvH/Bnu0V+7mMljYm/1QlDYALNIIaT/JcoZQFUN3w==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2225,17 +2250,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
-      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.2.0.tgz",
+      "integrity": "sha512-BOazBR0XjzsHE+2K1wpNxz5QZmrJgmm3+0Re0EVPYFGW8qndCWGNtXW/0lGKhecVPML8yyFeAmnUCIs7xM2wPw==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2255,15 +2280,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
-      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.2.0.tgz",
+      "integrity": "sha512-+OTK3FQHk5WMvdelz8v19PbEbx+CNT6VSpx7nVOvMNs5yJCKvmqBJBQ2ZSxROxhVDYn+CZOlmyrC56NSXzHf6g==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2277,13 +2302,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
-      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.2.0.tgz",
+      "integrity": "sha512-p9vOep8+7OVl6r/NREEYxf4HMAjV8JMYJ7Bos5fCFO0Wyi9AZEo0sCTliRd7R8+dlJXZEgcngSdxAUo/Q+CJow==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2297,13 +2322,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
-      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.2.0.tgz",
+      "integrity": "sha512-+eZVVxVeEnV5nVQJdey9ZsfyEVMls6VyWTIj8SmX0k5EbqGvnIfET+J2pYEuKQnDIHxy+syRMoRM6AHXdHYGIg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2315,13 +2340,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.2.0.tgz",
+      "integrity": "sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2333,16 +2358,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
-      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.2.0.tgz",
+      "integrity": "sha512-0jAmyRDN/aI265CbWZNZuQpFqiZuo+5otk2MylU9iVrz/4J7gSc+ZJ9cy4EHrEsW7PV8s1w18hIEsmcA1YgkKg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -2356,22 +2381,22 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
-      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.2.0.tgz",
+      "integrity": "sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/plugin-debug": "2.1.0",
-        "@docusaurus/plugin-google-analytics": "2.1.0",
-        "@docusaurus/plugin-google-gtag": "2.1.0",
-        "@docusaurus/plugin-sitemap": "2.1.0",
-        "@docusaurus/theme-classic": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-search-algolia": "2.1.0",
-        "@docusaurus/types": "2.1.0"
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/plugin-debug": "2.2.0",
+        "@docusaurus/plugin-google-analytics": "2.2.0",
+        "@docusaurus/plugin-google-gtag": "2.2.0",
+        "@docusaurus/plugin-sitemap": "2.2.0",
+        "@docusaurus/theme-classic": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-search-algolia": "2.2.0",
+        "@docusaurus/types": "2.2.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -2394,22 +2419,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
-      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.2.0.tgz",
+      "integrity": "sha512-kjbg/qJPwZ6H1CU/i9d4l/LcFgnuzeiGgMQlt6yPqKo0SOJIBMPuz7Rnu3r/WWbZFPi//o8acclacOzmXdUUEg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-translations": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -2433,16 +2458,16 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
-      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.2.0.tgz",
+      "integrity": "sha512-R8BnDjYoN90DCL75gP7qYQfSjyitXuP9TdzgsKDmSFPNyrdE3twtPNa2dIN+h+p/pr+PagfxwWbd6dn722A1Dw==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2461,18 +2486,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
-      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.2.0.tgz",
+      "integrity": "sha512-2h38B0tqlxgR2FZ9LpAkGrpDWVdXZ7vltfmTdX+4RsDs3A7khiNsmZB+x/x6sA4+G2V2CvrsPMlsYBy5X+cY1w==",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-translations": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -2491,9 +2516,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
-      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.2.0.tgz",
+      "integrity": "sha512-3T140AG11OjJrtKlY4pMZ5BzbGRDjNs2co5hJ6uYJG1bVWlhcaFGqkaZ5lCgKflaNHD7UHBHU9Ec5f69jTdd6w==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -2503,9 +2528,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
+      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2522,11 +2547,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
+      "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
       "dependencies": {
-        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -2555,9 +2580,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
-      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
+      "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2574,12 +2599,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
-      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
+      "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
       "dependencies": {
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -3678,9 +3703,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.0.tgz",
-      "integrity": "sha512-TLl/MSjtQ98mgkd8hngWkzSjE+dAWldZ1NpJtv2mT+ZoFJ2P2zDE85oF9WafJOXWN9FbVRmyxpO5H+qXcNaFng==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.1.tgz",
+      "integrity": "sha512-mvsPN3eK4E0bZG0/WlWJjeqe/bUD2KOEVOl0GyL/TGXn6wcpZU8NOuztGHCUKXkyg5gq6YzUakVTmnmSSO5Yiw==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -3796,9 +3821,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.8",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.8.tgz",
-      "integrity": "sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==",
+      "version": "10.4.13",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
+      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3810,8 +3835,8 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.3",
-        "caniuse-lite": "^1.0.30001373",
+        "browserslist": "^4.21.4",
+        "caniuse-lite": "^1.0.30001426",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -4085,9 +4110,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4099,10 +4124,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4231,9 +4256,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001373",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
-      "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==",
+      "version": "1.0.30001439",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
+      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
       "funding": [
         {
           "type": "opencollective",
@@ -4864,9 +4889,9 @@
       }
     },
     "node_modules/css-declaration-sorter": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.0.tgz",
-      "integrity": "sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
+      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
       "engines": {
         "node": "^10 || ^12 || >=14"
       },
@@ -5055,12 +5080,12 @@
       }
     },
     "node_modules/cssnano-preset-advanced": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.8.tgz",
-      "integrity": "sha512-xUlLLnEB1LjpEik+zgRNlk8Y/koBPPtONZjp7JKbXigeAmCrFvq9H0pXW5jJV45bQWAlmJ0sKy+IMr0XxLYQZg==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.9.tgz",
+      "integrity": "sha512-njnh4pp1xCsibJcEHnWZb4EEzni0ePMqPuPNyuWT4Z+YeXmsgqNuTPIljXFEXhxGsWs9183JkXgHxc1TcsahIg==",
       "dependencies": {
-        "autoprefixer": "^10.3.7",
-        "cssnano-preset-default": "^5.2.12",
+        "autoprefixer": "^10.4.12",
+        "cssnano-preset-default": "^5.2.13",
         "postcss-discard-unused": "^5.1.0",
         "postcss-merge-idents": "^5.1.1",
         "postcss-reduce-idents": "^5.2.0",
@@ -5074,24 +5099,24 @@
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "5.2.12",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.12.tgz",
-      "integrity": "sha512-OyCBTZi+PXgylz9HAA5kHyoYhfGcYdwFmyaJzWnzxuGRtnMw/kR6ilW9XzlzlRAtB6PLT/r+prYgkef7hngFew==",
+      "version": "5.2.13",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.13.tgz",
+      "integrity": "sha512-PX7sQ4Pb+UtOWuz8A1d+Rbi+WimBIxJTRyBdgGp1J75VU0r/HFQeLnMYgHiCAp6AR4rqrc7Y4R+1Rjk3KJz6DQ==",
       "dependencies": {
-        "css-declaration-sorter": "^6.3.0",
+        "css-declaration-sorter": "^6.3.1",
         "cssnano-utils": "^3.1.0",
         "postcss-calc": "^8.2.3",
         "postcss-colormin": "^5.3.0",
-        "postcss-convert-values": "^5.1.2",
+        "postcss-convert-values": "^5.1.3",
         "postcss-discard-comments": "^5.1.2",
         "postcss-discard-duplicates": "^5.1.0",
         "postcss-discard-empty": "^5.1.1",
         "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.6",
-        "postcss-merge-rules": "^5.1.2",
+        "postcss-merge-longhand": "^5.1.7",
+        "postcss-merge-rules": "^5.1.3",
         "postcss-minify-font-values": "^5.1.0",
         "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.3",
+        "postcss-minify-params": "^5.1.4",
         "postcss-minify-selectors": "^5.2.1",
         "postcss-normalize-charset": "^5.1.0",
         "postcss-normalize-display-values": "^5.1.0",
@@ -5099,11 +5124,11 @@
         "postcss-normalize-repeat-style": "^5.1.1",
         "postcss-normalize-string": "^5.1.0",
         "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.1",
         "postcss-normalize-url": "^5.1.0",
         "postcss-normalize-whitespace": "^5.1.1",
         "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.0",
+        "postcss-reduce-initial": "^5.1.1",
         "postcss-reduce-transforms": "^5.1.0",
         "postcss-svgo": "^5.1.0",
         "postcss-unique-selectors": "^5.1.1"
@@ -5480,9 +5505,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.204",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.204.tgz",
-      "integrity": "sha512-5Ojjtw9/c9HCXtMVE6SXVSHSNjmbFOXpKprl6mY/5moLSxLeWatuYA7KTD+RzJMxLRH6yNNQrqGz9p6IoNBMgw=="
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -6277,9 +6302,9 @@
       }
     },
     "node_modules/github-slugger": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz",
-      "integrity": "sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
+      "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -7514,9 +7539,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -8551,11 +8576,11 @@
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.2.tgz",
-      "integrity": "sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
+      "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
       "dependencies": {
-        "browserslist": "^4.20.3",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -8660,12 +8685,12 @@
       }
     },
     "node_modules/postcss-merge-longhand": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.6.tgz",
-      "integrity": "sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
+      "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.0"
+        "stylehacks": "^5.1.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
@@ -8675,11 +8700,11 @@
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.2.tgz",
-      "integrity": "sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.3.tgz",
+      "integrity": "sha512-LbLd7uFC00vpOuMvyZop8+vvhnfRGpp2S+IMQKeuOZZapPRY4SMq5ErjQeHbHsjCUgJkRNrlU+LmxsKIqPKQlA==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
         "cssnano-utils": "^3.1.0",
         "postcss-selector-parser": "^6.0.5"
@@ -8722,11 +8747,11 @@
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.3.tgz",
-      "integrity": "sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
+      "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       },
@@ -8888,11 +8913,11 @@
       }
     },
     "node_modules/postcss-normalize-unicode": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
-      "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
+      "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -8961,11 +8986,11 @@
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
-      "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.1.tgz",
+      "integrity": "sha512-//jeDqWcHPuXGZLoolFrUXBDyuEGbr9S2rMo19bkTIjBQ4PqkaO+oI8wua5BOUxpfi97i3PCoInsiFIEBfkm9w==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0"
       },
       "engines": {
@@ -9381,9 +9406,9 @@
       }
     },
     "node_modules/react-dev-utils/node_modules/loader-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
-      "integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+      "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -9572,9 +9597,9 @@
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
+      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.2",
         "use-composed-ref": "^1.3.0",
@@ -9628,25 +9653,14 @@
       }
     },
     "node_modules/recursive-readdir": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
-      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
       "dependencies": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.5"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/recursive-readdir/node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/regenerate": {
@@ -10373,29 +10387,18 @@
       }
     },
     "node_modules/serve-handler": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
-      "integrity": "sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
+      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
       "dependencies": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
         "fast-url-parser": "1.1.3",
         "mime-types": "2.1.18",
-        "minimatch": "3.0.4",
+        "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
         "path-to-regexp": "2.2.1",
         "range-parser": "1.2.0"
-      }
-    },
-    "node_modules/serve-handler/node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/serve-handler/node_modules/path-to-regexp": {
@@ -10861,11 +10864,11 @@
       }
     },
     "node_modules/stylehacks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
-      "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
+      "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-selector-parser": "^6.0.4"
       },
       "engines": {
@@ -11233,9 +11236,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
+      "version": "0.7.32",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
+      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
       "funding": [
         {
           "type": "opencollective",
@@ -11443,9 +11446,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -13810,25 +13813,48 @@
       "optional": true
     },
     "@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.0.tgz",
+      "integrity": "sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg=="
     },
     "@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.0.tgz",
+      "integrity": "sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==",
       "requires": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
+        "@algolia/autocomplete-core": "1.7.2",
+        "@algolia/autocomplete-preset-algolia": "1.7.2",
+        "@docsearch/css": "3.3.0",
         "algoliasearch": "^4.0.0"
+      },
+      "dependencies": {
+        "@algolia/autocomplete-core": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.2.tgz",
+          "integrity": "sha512-eclwUDC6qfApNnEfu1uWcL/rudQsn59tjEoUYZYE2JSXZrHLRjBUGMxiCoknobU2Pva8ejb0eRxpIYDtVVqdsw==",
+          "requires": {
+            "@algolia/autocomplete-shared": "1.7.2"
+          }
+        },
+        "@algolia/autocomplete-preset-algolia": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.2.tgz",
+          "integrity": "sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==",
+          "requires": {
+            "@algolia/autocomplete-shared": "1.7.2"
+          }
+        },
+        "@algolia/autocomplete-shared": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.2.tgz",
+          "integrity": "sha512-QCckjiC7xXHIUaIL3ektBtjJ0w7tTA3iqKcAE/Hjn1lZ5omp7i3Y4e09rAr9ZybqirL7AbxCLLq0Ra5DDPKeug=="
+        }
       }
     },
     "@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-Vd6XOluKQqzG12fEs9prJgDtyn6DPok9vmUWDR2E6/nV5Fl9SVkhEQOBxwObjk3kQh7OY7vguFaLh0jqdApWsA==",
       "requires": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -13840,13 +13866,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/cssnano-preset": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -13904,9 +13930,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.2.0.tgz",
+      "integrity": "sha512-mAAwCo4n66TMWBH1kXnHVZsakW9VAXJzTO4yZukuL3ro4F+JtkMwKfh42EG75K/J/YIFQG5I/Bzy0UH/hFxaTg==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -13915,23 +13941,23 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
-      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
+      "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
-      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
+      "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -13948,12 +13974,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
+      "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
+        "@docusaurus/types": "2.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -13963,17 +13989,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
-      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.2.0.tgz",
+      "integrity": "sha512-0mWBinEh0a5J2+8ZJXJXbrCk1tSTNf7Nm4tYAl5h2/xx+PvH/Bnu0V+7mMljYm/1QlDYALNIIaT/JcoZQFUN3w==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -13986,17 +14012,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
-      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.2.0.tgz",
+      "integrity": "sha512-BOazBR0XjzsHE+2K1wpNxz5QZmrJgmm3+0Re0EVPYFGW8qndCWGNtXW/0lGKhecVPML8yyFeAmnUCIs7xM2wPw==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -14009,88 +14035,88 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
-      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.2.0.tgz",
+      "integrity": "sha512-+OTK3FQHk5WMvdelz8v19PbEbx+CNT6VSpx7nVOvMNs5yJCKvmqBJBQ2ZSxROxhVDYn+CZOlmyrC56NSXzHf6g==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
-      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.2.0.tgz",
+      "integrity": "sha512-p9vOep8+7OVl6r/NREEYxf4HMAjV8JMYJ7Bos5fCFO0Wyi9AZEo0sCTliRd7R8+dlJXZEgcngSdxAUo/Q+CJow==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
-      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.2.0.tgz",
+      "integrity": "sha512-+eZVVxVeEnV5nVQJdey9ZsfyEVMls6VyWTIj8SmX0k5EbqGvnIfET+J2pYEuKQnDIHxy+syRMoRM6AHXdHYGIg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.2.0.tgz",
+      "integrity": "sha512-6SOgczP/dYdkqUMGTRqgxAS1eTp6MnJDAQMy8VCF1QKbWZmlkx4agHDexihqmYyCujTYHqDAhm1hV26EET54NQ==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
-      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.2.0.tgz",
+      "integrity": "sha512-0jAmyRDN/aI265CbWZNZuQpFqiZuo+5otk2MylU9iVrz/4J7gSc+ZJ9cy4EHrEsW7PV8s1w18hIEsmcA1YgkKg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
-      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.2.0.tgz",
+      "integrity": "sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/plugin-debug": "2.1.0",
-        "@docusaurus/plugin-google-analytics": "2.1.0",
-        "@docusaurus/plugin-google-gtag": "2.1.0",
-        "@docusaurus/plugin-sitemap": "2.1.0",
-        "@docusaurus/theme-classic": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-search-algolia": "2.1.0",
-        "@docusaurus/types": "2.1.0"
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/plugin-debug": "2.2.0",
+        "@docusaurus/plugin-google-analytics": "2.2.0",
+        "@docusaurus/plugin-google-gtag": "2.2.0",
+        "@docusaurus/plugin-sitemap": "2.2.0",
+        "@docusaurus/theme-classic": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-search-algolia": "2.2.0",
+        "@docusaurus/types": "2.2.0"
       }
     },
     "@docusaurus/react-loadable": {
@@ -14103,22 +14129,22 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
-      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.2.0.tgz",
+      "integrity": "sha512-kjbg/qJPwZ6H1CU/i9d4l/LcFgnuzeiGgMQlt6yPqKo0SOJIBMPuz7Rnu3r/WWbZFPi//o8acclacOzmXdUUEg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-translations": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -14135,16 +14161,16 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
-      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.2.0.tgz",
+      "integrity": "sha512-R8BnDjYoN90DCL75gP7qYQfSjyitXuP9TdzgsKDmSFPNyrdE3twtPNa2dIN+h+p/pr+PagfxwWbd6dn722A1Dw==",
       "requires": {
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -14156,18 +14182,18 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
-      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.2.0.tgz",
+      "integrity": "sha512-2h38B0tqlxgR2FZ9LpAkGrpDWVdXZ7vltfmTdX+4RsDs3A7khiNsmZB+x/x6sA4+G2V2CvrsPMlsYBy5X+cY1w==",
       "requires": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-translations": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -14179,18 +14205,18 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
-      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.2.0.tgz",
+      "integrity": "sha512-3T140AG11OjJrtKlY4pMZ5BzbGRDjNs2co5hJ6uYJG1bVWlhcaFGqkaZ5lCgKflaNHD7UHBHU9Ec5f69jTdd6w==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
+      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -14203,11 +14229,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
+      "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
       "requires": {
-        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -14225,20 +14251,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
-      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
+      "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
-      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
+      "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
       "requires": {
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -15108,9 +15134,9 @@
       }
     },
     "algoliasearch-helper": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.0.tgz",
-      "integrity": "sha512-TLl/MSjtQ98mgkd8hngWkzSjE+dAWldZ1NpJtv2mT+ZoFJ2P2zDE85oF9WafJOXWN9FbVRmyxpO5H+qXcNaFng==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.1.tgz",
+      "integrity": "sha512-mvsPN3eK4E0bZG0/WlWJjeqe/bUD2KOEVOl0GyL/TGXn6wcpZU8NOuztGHCUKXkyg5gq6YzUakVTmnmSSO5Yiw==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -15198,12 +15224,12 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "autoprefixer": {
-      "version": "10.4.8",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.8.tgz",
-      "integrity": "sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==",
+      "version": "10.4.13",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
+      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
       "requires": {
-        "browserslist": "^4.21.3",
-        "caniuse-lite": "^1.0.30001373",
+        "browserslist": "^4.21.4",
+        "caniuse-lite": "^1.0.30001426",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -15420,14 +15446,14 @@
       }
     },
     "browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "requires": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       }
     },
     "buffer-from": {
@@ -15519,9 +15545,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001373",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
-      "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ=="
+      "version": "1.0.30001439",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
+      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A=="
     },
     "ccount": {
       "version": "1.1.0",
@@ -15966,9 +15992,9 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
     "css-declaration-sorter": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.0.tgz",
-      "integrity": "sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.1.tgz",
+      "integrity": "sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==",
       "requires": {}
     },
     "css-loader": {
@@ -16078,12 +16104,12 @@
       }
     },
     "cssnano-preset-advanced": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.8.tgz",
-      "integrity": "sha512-xUlLLnEB1LjpEik+zgRNlk8Y/koBPPtONZjp7JKbXigeAmCrFvq9H0pXW5jJV45bQWAlmJ0sKy+IMr0XxLYQZg==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.9.tgz",
+      "integrity": "sha512-njnh4pp1xCsibJcEHnWZb4EEzni0ePMqPuPNyuWT4Z+YeXmsgqNuTPIljXFEXhxGsWs9183JkXgHxc1TcsahIg==",
       "requires": {
-        "autoprefixer": "^10.3.7",
-        "cssnano-preset-default": "^5.2.12",
+        "autoprefixer": "^10.4.12",
+        "cssnano-preset-default": "^5.2.13",
         "postcss-discard-unused": "^5.1.0",
         "postcss-merge-idents": "^5.1.1",
         "postcss-reduce-idents": "^5.2.0",
@@ -16091,24 +16117,24 @@
       }
     },
     "cssnano-preset-default": {
-      "version": "5.2.12",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.12.tgz",
-      "integrity": "sha512-OyCBTZi+PXgylz9HAA5kHyoYhfGcYdwFmyaJzWnzxuGRtnMw/kR6ilW9XzlzlRAtB6PLT/r+prYgkef7hngFew==",
+      "version": "5.2.13",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.13.tgz",
+      "integrity": "sha512-PX7sQ4Pb+UtOWuz8A1d+Rbi+WimBIxJTRyBdgGp1J75VU0r/HFQeLnMYgHiCAp6AR4rqrc7Y4R+1Rjk3KJz6DQ==",
       "requires": {
-        "css-declaration-sorter": "^6.3.0",
+        "css-declaration-sorter": "^6.3.1",
         "cssnano-utils": "^3.1.0",
         "postcss-calc": "^8.2.3",
         "postcss-colormin": "^5.3.0",
-        "postcss-convert-values": "^5.1.2",
+        "postcss-convert-values": "^5.1.3",
         "postcss-discard-comments": "^5.1.2",
         "postcss-discard-duplicates": "^5.1.0",
         "postcss-discard-empty": "^5.1.1",
         "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.6",
-        "postcss-merge-rules": "^5.1.2",
+        "postcss-merge-longhand": "^5.1.7",
+        "postcss-merge-rules": "^5.1.3",
         "postcss-minify-font-values": "^5.1.0",
         "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.3",
+        "postcss-minify-params": "^5.1.4",
         "postcss-minify-selectors": "^5.2.1",
         "postcss-normalize-charset": "^5.1.0",
         "postcss-normalize-display-values": "^5.1.0",
@@ -16116,11 +16142,11 @@
         "postcss-normalize-repeat-style": "^5.1.1",
         "postcss-normalize-string": "^5.1.0",
         "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.1",
         "postcss-normalize-url": "^5.1.0",
         "postcss-normalize-whitespace": "^5.1.1",
         "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.0",
+        "postcss-reduce-initial": "^5.1.1",
         "postcss-reduce-transforms": "^5.1.0",
         "postcss-svgo": "^5.1.0",
         "postcss-unique-selectors": "^5.1.1"
@@ -16399,9 +16425,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-to-chromium": {
-      "version": "1.4.204",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.204.tgz",
-      "integrity": "sha512-5Ojjtw9/c9HCXtMVE6SXVSHSNjmbFOXpKprl6mY/5moLSxLeWatuYA7KTD+RzJMxLRH6yNNQrqGz9p6IoNBMgw=="
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -16975,9 +17001,9 @@
       }
     },
     "github-slugger": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.4.0.tgz",
-      "integrity": "sha512-w0dzqw/nt51xMVmlaV1+JRzN+oCa1KfcgGEWhxUG16wbdA+Xnt/yoFO8Z8x/V82ZcZ0wy6ln9QDup5avbhiDhQ=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
+      "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
     },
     "glob": {
       "version": "7.2.3",
@@ -17859,9 +17885,9 @@
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
     },
     "loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -18603,11 +18629,11 @@
       }
     },
     "postcss-convert-values": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.2.tgz",
-      "integrity": "sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
+      "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
       "requires": {
-        "browserslist": "^4.20.3",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       }
     },
@@ -18663,20 +18689,20 @@
       }
     },
     "postcss-merge-longhand": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.6.tgz",
-      "integrity": "sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
+      "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
       "requires": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.0"
+        "stylehacks": "^5.1.1"
       }
     },
     "postcss-merge-rules": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.2.tgz",
-      "integrity": "sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.3.tgz",
+      "integrity": "sha512-LbLd7uFC00vpOuMvyZop8+vvhnfRGpp2S+IMQKeuOZZapPRY4SMq5ErjQeHbHsjCUgJkRNrlU+LmxsKIqPKQlA==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
         "cssnano-utils": "^3.1.0",
         "postcss-selector-parser": "^6.0.5"
@@ -18701,11 +18727,11 @@
       }
     },
     "postcss-minify-params": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.3.tgz",
-      "integrity": "sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
+      "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       }
@@ -18797,11 +18823,11 @@
       }
     },
     "postcss-normalize-unicode": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
-      "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
+      "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       }
     },
@@ -18840,11 +18866,11 @@
       }
     },
     "postcss-reduce-initial": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
-      "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.1.tgz",
+      "integrity": "sha512-//jeDqWcHPuXGZLoolFrUXBDyuEGbr9S2rMo19bkTIjBQ4PqkaO+oI8wua5BOUxpfi97i3PCoInsiFIEBfkm9w==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0"
       }
     },
@@ -19150,9 +19176,9 @@
           }
         },
         "loader-utils": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
-          "integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ=="
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+          "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw=="
         },
         "locate-path": {
           "version": "6.0.0",
@@ -19290,9 +19316,9 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
+      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
       "requires": {
         "@babel/runtime": "^7.10.2",
         "use-composed-ref": "^1.3.0",
@@ -19331,21 +19357,11 @@
       }
     },
     "recursive-readdir": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
-      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
       "requires": {
-        "minimatch": "3.0.4"
-      },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
+        "minimatch": "^3.0.5"
       }
     },
     "regenerate": {
@@ -19898,28 +19914,20 @@
       }
     },
     "serve-handler": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
-      "integrity": "sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.5.tgz",
+      "integrity": "sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==",
       "requires": {
         "bytes": "3.0.0",
         "content-disposition": "0.5.2",
         "fast-url-parser": "1.1.3",
         "mime-types": "2.1.18",
-        "minimatch": "3.0.4",
+        "minimatch": "3.1.2",
         "path-is-inside": "1.0.2",
         "path-to-regexp": "2.2.1",
         "range-parser": "1.2.0"
       },
       "dependencies": {
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
         "path-to-regexp": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
@@ -20273,11 +20281,11 @@
       }
     },
     "stylehacks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
-      "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
+      "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-selector-parser": "^6.0.4"
       }
     },
@@ -20529,9 +20537,9 @@
       "peer": true
     },
     "ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
+      "version": "0.7.32",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
+      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw=="
     },
     "unherit": {
       "version": "1.1.3",
@@ -20661,9 +20669,9 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "update-browserslist-db": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
-      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@cmfcmf/docusaurus-search-local": "^0.11.0",
-    "@docusaurus/core": "2.1.0",
-    "@docusaurus/preset-classic": "2.1.0",
+    "@docusaurus/core": "^2.2.0",
+    "@docusaurus/preset-classic": "^2.2.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "docusaurus-plugin-image-zoom": "^0.1.1",
@@ -25,7 +25,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.1.0"
+    "@docusaurus/module-type-aliases": "^2.2.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Description

Docusaurus released a new version. Also, the current packages has some vulnerabilities.

## Solution description

Bump docusaurus from `2.1.0` to `2.2.0` and apply `npm audit --fix` to fix vulnerabilities that don't need attention.

## Checklist

- [ ] Made great code
